### PR TITLE
[Lab5] Add tx err monitor CLI commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6044,6 +6044,32 @@ def unbind(ctx, interface_name):
         config_db.set_entry(table_name, interface_name, None)
 
     click.echo("Interface {} IP disabled and address(es) removed due to unbinding VRF.".format(interface_name))
+
+#
+# 'tx_err_monitoring_threshold' subcommand ('config tx_err_monitoring_threshold')
+#
+
+@config.command()
+@click.argument('threshold', metavar='<threshold>', required=True, type=click.IntRange(0, 4294967295))
+def tx_err_monitoring_threshold(threshold):
+    """Set threshold of tx error monitoring"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_ERR_CFG", "config", {"threshold": threshold})
+
+#
+# 'tx_err_monitoring_period' subcommand ('config tx_err_monitoring_period')
+#
+
+@config.command()
+@click.argument('period', metavar='<period>', required=True, type=click.IntRange(1, 4294967295))
+def tx_err_monitoring_period(period):
+    """Set period of tx error monitoring"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_ERR_CFG", "config", {"period": period})
+
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')
 #

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -62,6 +62,73 @@ def interfaces():
     pass
 
 
+#
+# 'tx_err' subcommand ("show interfaces tx-err-monitoring-states")
+#
+
+@interfaces.command()
+def tx_err_monitoring_states():
+    """Show Interfaces tx err monitoring information"""
+
+    localhost = '127.0.0.1'
+    state_db = SonicV2Connector(host=localhost)
+    state_db.connect(state_db.STATE_DB, False)
+    tx_err_state_prefix = "TX_ERR_STATE|"
+    _hash = '{}{}'.format(tx_err_state_prefix, '*')
+    tx_err_port_state_keys = state_db.keys(state_db.STATE_DB, _hash)
+    tx_err_state_key = "state"
+    empty_string = ""
+    table = []
+
+    for key in natsorted(tx_err_port_state_keys):
+        row = []
+        # TX_ERR_STATE|Ethernet0 -> Ethernet0
+        port_name = key.replace(tx_err_state_prefix, empty_string) 
+        row.append(port_name)
+        port_state = state_db.get(state_db.STATE_DB, tx_err_state_prefix + port_name, tx_err_state_key)
+        row.append(port_state)
+        table.append(row)
+
+    click.echo(tabulate(table, headers = ['IFACE', 'STATE'], tablefmt="grid"))
+
+
+#
+# 'tx_err' subcommand ("show interfaces tx-err-monitoring-config")
+#
+
+@interfaces.command()
+def tx_err_monitoring_config():
+    """Show Interfaces tx err monitoring configuration"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    tx_err_cfg_table_name = "TX_ERR_CFG"
+    tx_err_cfg_key = "config"
+    tx_err_monitor_time_period_key = "period"
+    tx_err_monitor_threshold_key = "threshold"
+    empty_string = ""
+    empty_config = True
+    table = []
+    row = []
+
+    cfg = config_db.get_entry(tx_err_cfg_table_name, tx_err_cfg_key)
+    if cfg is not None:
+        if tx_err_monitor_time_period_key in cfg:
+            row.append(cfg[tx_err_monitor_time_period_key])
+            empty_config = False
+        else:
+            row.append(empty_string)
+        if tx_err_monitor_threshold_key in cfg:
+            row.append(cfg[tx_err_monitor_threshold_key])
+            empty_config = False
+        else:
+            row.append(empty_string)
+    if not empty_config:
+        table.append(row)
+
+    click.echo(tabulate(table, headers = ['PERIOD', 'THRESHOLD'], tablefmt="grid"))
+
+
 # 'alias' subcommand ("show interfaces alias")
 @interfaces.command()
 @click.argument('interfacename', required=False)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added new CLI commands to manage TX error monitoring configuration and view port states.

#### How I did it
Created new subcommands under config to set tx err monitoring parameters:
tx_err_monitoring_threshold – to set the TX error threshold
tx_err_monitoring_period – to set the monitoring period

Added subcommands under show interfaces to display:
tx_err_monitoring_config – current configuration values
tx_err_monitoring_states – current port states related to TX error monitoring

#### How to verify it
config tx-err-monitoring-period 20  
config tx-err-monitoring-threshold 1  
show interfaces tx-err-monitoring-config  
show interfaces tx-err-monitoring-states

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

