### PR TITLE
[db_migrator] Add version_202411_02

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1293,6 +1293,14 @@ class DBMigrator():
         Version 202411_01.
         """
         log.log_info('Handling version_202411_01')
+        self.set_version('version_202411_02')
+        return 'version_202411_02'
+
+    def version_202411_02(self):
+        """
+        Version 202411_02.
+        """
+        log.log_info('Handling version_202411_02')
         self.set_version('version_202505_01')
         return 'version_202505_01'
 

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -88,9 +88,9 @@ class TestVersionComparison(object):
                                   {'v1': 'version_202311_02', 'v2': 'version_202311_01', 'result': True},
                                   {'v1': 'version_202305_01', 'v2': 'version_202311_01', 'result': False},
                                   {'v1': 'version_202311_01', 'v2': 'version_202305_01', 'result': True},
-                                  {'v1': 'version_202405_01', 'v2': 'version_202411_01', 'result': False},
-                                  {'v1': 'version_202411_01', 'v2': 'version_202405_01', 'result': True},
-                                  {'v1': 'version_202411_01', 'v2': 'version_master_01', 'result': False},
+                                  {'v1': 'version_202405_01', 'v2': 'version_202411_02', 'result': False},
+                                  {'v1': 'version_202411_02', 'v2': 'version_202405_01', 'result': True},
+                                  {'v1': 'version_202411_02', 'v2': 'version_master_01', 'result': False},
                                   {'v1': 'version_202311_01', 'v2': 'version_master_01', 'result': False},
                                   {'v1': 'version_master_01', 'v2': 'version_202311_01', 'result': True},
                                   {'v1': 'version_master_01', 'v2': 'version_master_02', 'result': False},
@@ -386,7 +386,7 @@ class TestDnsNameserverMigrator(object):
         dbmgtr.migrate()
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'dns-nameserver-expected')
         expected_db = Db()
-        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_01')
+        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_02')
         resulting_keys = dbmgtr.configDB.keys(dbmgtr.configDB.CONFIG_DB, 'DNS_NAMESERVER*')
         expected_keys = expected_db.cfgdb.keys(expected_db.cfgdb.CONFIG_DB, 'DNS_NAMESERVER*')
 
@@ -905,7 +905,7 @@ class TestMain(object):
     @mock.patch('swsscommon.swsscommon.SonicDBConfig.isInit', mock.MagicMock(return_value=False))
     @mock.patch('swsscommon.swsscommon.SonicDBConfig.initialize', mock.MagicMock())
     def test_init_no_namespace(self, mock_args):
-        mock_args.return_value = argparse.Namespace(namespace=None, operation='version_202411_01', socket=None)
+        mock_args.return_value = argparse.Namespace(namespace=None, operation='version_202411_02', socket=None)
         import db_migrator
         db_migrator.main()
 
@@ -913,7 +913,7 @@ class TestMain(object):
     @mock.patch('swsscommon.swsscommon.SonicDBConfig.isGlobalInit', mock.MagicMock(return_value=False))
     @mock.patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig', mock.MagicMock())
     def test_init_namespace(self, mock_args):
-        mock_args.return_value = argparse.Namespace(namespace="asic0", operation='version_202411_01', socket=None)
+        mock_args.return_value = argparse.Namespace(namespace="asic0", operation='version_202411_02', socket=None)
         import db_migrator
         db_migrator.main()
 
@@ -950,7 +950,7 @@ class TestGNMIMigrator(object):
         dbmgtr.migrate()
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'gnmi-minigraph-expected')
         expected_db = Db()
-        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_01')
+        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_02')
         resulting_table = dbmgtr.configDB.get_table("GNMI")
         expected_table = expected_db.cfgdb.get_table("GNMI")
 
@@ -966,7 +966,7 @@ class TestGNMIMigrator(object):
         dbmgtr.migrate()
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'gnmi-configdb-expected')
         expected_db = Db()
-        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_01')
+        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_202411_02')
         resulting_table = dbmgtr.configDB.get_table("GNMI")
         expected_table = expected_db.cfgdb.get_table("GNMI")
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed migration error during upgrade from 202411_02.

#### How I did it
- Added version_202411_02 function in db_migrator to support proper migration during upgrade
(called dynamically via getattr from the migrate function).
- Updated db_migrator_test accordingly.

#### How to verify it
Manual:
- Use canonical setup with 202411 image
- Verify the version in config_db and Redis is version_202411_02
hget VERSIONS|DATABASE VERSION
vim /etc/sonic/config_db.json
- Install master image and reboot
- Check syslog for db_migrator errors or run config reload

Automatic:
- Use canonical setup with 202411 image
- Verify the version in config_db and Redis is version_202411_02
- Run test_deploy-and-upgrade as in the bug description

Additional Option:
Run the following command to migrate (to 202505_01):
/usr/local/bin/db_migrator.py -o migrate

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

