### PR TITLE
[BMC] Add new BMC CLIs for manual session management and reset root password

### DIFF
--- a/config/bmc.py
+++ b/config/bmc.py
@@ -1,0 +1,70 @@
+import click
+
+
+# 'bmc' group ('config bmc ...')
+@click.group('bmc')
+def bmc():
+    """BMC (Baseboard Management Controller) configuration tasks"""
+    pass
+
+
+# config bmc reset-root-password
+@bmc.command('reset-root-password')
+def reset_root_password():
+    """Reset BMC root password to default"""
+    try:
+        import sonic_platform
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        bmc = chassis.get_bmc()
+        if bmc is None:
+            click.echo("BMC is not available on this platform")
+            return
+        ret, msg = bmc.reset_root_password()
+        if ret == 0:
+            click.echo("BMC root password reset successful")
+        else:
+            click.echo(f"BMC root password reset failed: {msg}")
+    except Exception as e:
+        click.echo(f'Error: {str(e)}')
+
+
+# config bmc open-session
+@bmc.command('open-session')
+def open_session():
+    """Open a session with the BMC"""
+    try:
+        import sonic_platform
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        bmc = chassis.get_bmc()
+        if bmc is None:
+            click.echo("BMC is not available on this platform")
+            return
+        ret, (msg, credentials) = bmc.open_session()
+        if ret != 0 or not credentials:
+            click.echo(f"Failed to open session: {msg}")
+            return
+        click.echo(f"Session ID: {credentials[0]}")
+        click.echo(f"Token: {credentials[1]}")
+    except Exception as e:
+        click.echo(f'Error: {str(e)}')
+
+
+# config bmc close-session --session-id <session-id>
+@bmc.command('close-session')
+@click.option('-s', '--session-id', required=True, help='Session ID to close')
+def close_session(session_id):
+    """Close a session with the BMC"""
+    try:
+        import sonic_platform
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        bmc = chassis.get_bmc()
+        if bmc is None:
+            click.echo("BMC is not available on this platform")
+            return
+        ret, msg = bmc.close_session(session_id)
+        if ret == 0:
+            click.echo("Session closed successfully")
+        else:
+            click.echo(f"Failed to close session: {msg}")
+    except Exception as e:
+        click.echo(f'Error: {str(e)}')

--- a/config/main.py
+++ b/config/main.py
@@ -50,6 +50,7 @@ from utilities_common.flock import try_lock
 from .utils import log
 
 from . import aaa
+from . import bmc
 from . import chassis_modules
 from . import console
 from . import feature
@@ -1723,6 +1724,7 @@ def config(ctx):
 config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
 config.add_command(aaa.radius)
+config.add_command(bmc.bmc)
 config.add_command(chassis_modules.chassis)
 config.add_command(console.console)
 config.add_command(fabric.fabric)

--- a/tests/bmc_test.py
+++ b/tests/bmc_test.py
@@ -1,0 +1,285 @@
+import os
+import sys
+from unittest import mock
+from click.testing import CliRunner
+from mock import MagicMock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+import config.bmc as bmc
+
+
+class TestBmcResetRootPassword(object):
+    """Test class for 'config bmc reset-root-password' command"""
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_reset_root_password_success(self):
+        """Test successful root password reset"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.reset_root_password.return_value = (0, "Password reset successful")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.reset_root_password, [])
+            assert result.exit_code == 0
+            assert "BMC root password reset successful" in result.output
+            mock_bmc.reset_root_password.assert_called_once()
+
+    def test_reset_root_password_failure(self):
+        """Test failed root password reset"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.reset_root_password.return_value = (1, "Password reset failed")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.reset_root_password, [])
+            assert result.exit_code == 0
+            assert "BMC root password reset failed: Password reset failed" in result.output
+            mock_bmc.reset_root_password.assert_called_once()
+
+    def test_reset_root_password_bmc_not_available(self):
+        """Test when BMC is not available"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = None
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.reset_root_password, [])
+            assert result.exit_code == 0
+            assert "BMC is not available on this platform" in result.output
+
+    def test_reset_root_password_exception(self):
+        """Test when an exception occurs"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.side_effect = Exception("Test exception")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.reset_root_password, [])
+            assert result.exit_code == 0
+            assert "Error: Test exception" in result.output
+
+
+class TestBmcOpenSession(object):
+    """Test class for 'config bmc open-session' command"""
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_open_session_success(self):
+        """Test successful session opening"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.open_session.return_value = (0, ("Login successful", ("session_123", "token_abc")))
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.open_session, [])
+            assert result.exit_code == 0
+            assert "Session ID: session_123" in result.output
+            assert "Token: token_abc" in result.output
+            mock_bmc.open_session.assert_called_once()
+
+    def test_open_session_failure_no_credentials(self):
+        """Test failed session opening with no credentials"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.open_session.return_value = (1, ("Login failed", None))
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.open_session, [])
+            assert result.exit_code == 0
+            assert "Failed to open session: Login failed" in result.output
+            mock_bmc.open_session.assert_called_once()
+
+    def test_open_session_failure_empty_credentials(self):
+        """Test failed session opening with empty credentials"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.open_session.return_value = (0, ("Login successful", ()))
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.open_session, [])
+            assert result.exit_code == 0
+            assert "Failed to open session: Login successful" in result.output
+            mock_bmc.open_session.assert_called_once()
+
+    def test_open_session_bmc_not_available(self):
+        """Test when BMC is not available"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = None
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.open_session, [])
+            assert result.exit_code == 0
+            assert "BMC is not available on this platform" in result.output
+
+    def test_open_session_exception(self):
+        """Test when an exception occurs"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.side_effect = Exception("Test exception")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.open_session, [])
+            assert result.exit_code == 0
+            assert "Error: Test exception" in result.output
+
+
+class TestBmcCloseSession(object):
+    """Test class for 'config bmc close-session' command"""
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_close_session_success(self):
+        """Test successful session closing"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.close_session.return_value = (0, "Session closed successfully")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.close_session, ['--session-id', 'session_123'])
+            assert result.exit_code == 0
+            assert "Session closed successfully" in result.output
+            mock_bmc.close_session.assert_called_once_with('session_123')
+
+    def test_close_session_failure(self):
+        """Test failed session closing"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_bmc = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.close_session.return_value = (1, "Session not found")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.close_session, ['--session-id', 'invalid_session'])
+            assert result.exit_code == 0
+            assert "Failed to close session: Session not found" in result.output
+            mock_bmc.close_session.assert_called_once_with('invalid_session')
+
+    def test_close_session_bmc_not_available(self):
+        """Test when BMC is not available"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = None
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.close_session, ['--session-id', 'session_123'])
+            assert result.exit_code == 0
+            assert "BMC is not available on this platform" in result.output
+
+    def test_close_session_exception(self):
+        """Test when an exception occurs"""
+        runner = CliRunner()
+        mock_sonic_platform = MagicMock()
+        mock_platform = MagicMock()
+        mock_chassis = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.side_effect = Exception("Test exception")
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = runner.invoke(bmc.close_session, ['--session-id', 'session_123'])
+            assert result.exit_code == 0
+            assert "Error: Test exception" in result.output
+
+    def test_close_session_missing_session_id(self):
+        """Test when session-id parameter is missing"""
+        runner = CliRunner()
+        result = runner.invoke(bmc.close_session, [])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "Error" in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added new BMC CLIs of:
- Reset the BMC root password
- Manually open a BMC session to get a token
- Manually close a BMC session

#### How I did it
Create the relevant CLI methods using the BMC object.

#### How to verify it
config bmc reset-root-password
config bmc open-session
config bmc close-session --session-id SESSION_ID

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

