### PR TITLE
[BMC] Align is_bmc_supported check for the new infra

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2201,13 +2201,7 @@ save_log_files() {
 #  0 if BMC is supported, 1 otherwise
 ###############################################################################
 is_bmc_supported() {
-    local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
-    # Check if the required file exists
-    if [ ! -f /usr/share/sonic/device/$platform/bmc.json ]; then
-        return 1
-    else
-        return 0
-    fi
+    python3 -c "from sonic_py_common import device_info; import sys; sys.exit(0 if (device_info.is_switch_host() and device_info.get_bmc_data()) else 1)"
 }
 
 ###############################################################################


### PR DESCRIPTION
#### Why I did it
The BMC support check in `generate_dump` was aligned with the new infrastructure flow. Instead of checking
for platform-local `bmc.json` assumptions, the logic now validates host-side role and runtime BMC data from
the canonical source used by the system.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Updated `generate_dump` BMC detection to use `device_info.is_switch_host()` together with
  `device_info.get_bmc_data()`.
- Removed reliance on legacy platform-folder `bmc.json` existence behavior for this path.
- Kept the `generate_dump` flow behavior intact while aligning detection to runtime
  `/etc/sonic/bmc.json`-based APIs.

#### How to verify it
- Run `show techsupport` (or `generate_dump`) on:
  - a switch-host platform with valid BMC data and verify BMC-related flow executes.
  - a non-switch-host / missing-BMC-data platform and verify BMC path is skipped.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [ ] <image-version-1>

#### Description for the changelog
[BMC] Align is_bmc_supported check for the new infra